### PR TITLE
Harden `discover_ICOS_files()` when no legacy data exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data/*
 plot_fluxnet.html
 plot_fluxnet_files/
 rsconnect/
+.vscode/settings.json

--- a/R/fcn_utility_FLUXNET.R
+++ b/R/fcn_utility_FLUXNET.R
@@ -254,6 +254,8 @@ discover_ICOS_files <- function(data_dir = "data") {
       remove  = FALSE,
       convert = TRUE
     ) %>%
+    mutate(across(everything(), as.character)) %>% 
+    mutate(across(ends_with("year"), as.integer)) %>% 
     select(path, filename, data_center, site, data_product,
            dataset, time_integral,
            start_year, end_year)
@@ -277,6 +279,8 @@ discover_ICOS_files <- function(data_dir = "data") {
       start_year = NA_integer_,
       end_year   = NA_integer_
     ) %>%
+    mutate(across(everything(), as.character)) %>% 
+    mutate(across(ends_with("year"), as.integer)) %>% 
     select(path, filename, data_center, site, data_product,
            dataset, time_integral,
            start_year, end_year)


### PR DESCRIPTION
Fix for #19 