### PR TITLE
Whittaker biome plot with NEE heatmap

### DIFF
--- a/whittaker-heatmap.R
+++ b/whittaker-heatmap.R
@@ -80,7 +80,7 @@ ggplot() +
   geom_polygon(
     data = borders_df,
     aes(x = temp_c, y = precip_cm, color = biome),
-    linewidth = 1.5,  # <- might need to tweak this number
+    linewidth = 1.5, # <- might need to tweak this number
     fill = NA
   ) +
   scale_color_manual(
@@ -88,7 +88,7 @@ ggplot() +
     breaks = names(Ricklefs_colors),
     labels = names(Ricklefs_colors),
     values = Ricklefs_colors,
-  )  +
+  ) +
   labs(x = "Temperature (C)", y = "Precipitation (cm y<sup>-1</sup>)") +
   theme_minimal() +
   theme(legend.title = element_markdown(), axis.title.y = element_markdown())


### PR DESCRIPTION
Adds a script that creates this plot:

<img width="819" height="573" alt="image" src="https://github.com/user-attachments/assets/6a7e6f80-2dd5-4fb3-b9dc-f38cd022f4d5" />

It was tricky to get the biome outlines to not overlap and involves a round trip through an sf object, but I think using the biome outlines ontop of the heatmap is really the only way to combine these plots.

I find it odd that so much data is not any *any* biome.  This plot also filters out quite a few datapoints by restricting precip < 500.  With the full Ameriflux dataset, the Whittaker biomes are barely visible because the y-axis goes so high:

<img width="819" height="573" alt="image" src="https://github.com/user-attachments/assets/d4a06114-a01f-4c93-a642-c959ac447932" />

